### PR TITLE
Fix attacher

### DIFF
--- a/internal/tree/attacher_bucket.go
+++ b/internal/tree/attacher_bucket.go
@@ -40,6 +40,7 @@ func (teb *Bucket) Destroy() {
 	teb.deletePropertyAllLocal()
 	teb.deletePropertyAllInherited()
 	teb.deleteCheckLocalAll()
+	teb.deleteCheckAllInherited()
 
 	wg := new(sync.WaitGroup)
 	for child := range teb.Children {

--- a/internal/tree/attacher_cluster.go
+++ b/internal/tree/attacher_cluster.go
@@ -38,7 +38,9 @@ func (tec *Cluster) ReAttach(a AttachRequest) {
 		panic(`Cluster.ReAttach: not attached`)
 	}
 	tec.deletePropertyAllInherited()
-	// TODO delete all inherited checks + check instances
+	tec.deleteCheckAllInherited()
+	tec.deleteCheckAllInherited()
+	tec.updateCheckInstances()
 
 	tec.Parent.Unlink(UnlinkRequest{
 		ParentType: tec.Parent.(Builder).GetType(),
@@ -77,6 +79,7 @@ func (tec *Cluster) Destroy() {
 	tec.deletePropertyAllLocal()
 	tec.deletePropertyAllInherited()
 	tec.deleteCheckLocalAll()
+	tec.deleteCheckAllInherited()
 	tec.updateCheckInstances()
 
 	wg := new(sync.WaitGroup)
@@ -110,6 +113,8 @@ func (tec *Cluster) Detach() {
 	bucket := tec.Parent.(Bucketeer).GetBucket()
 
 	tec.deletePropertyAllInherited()
+	tec.deleteCheckAllInherited()
+	tec.updateCheckInstances()
 	// TODO delete all inherited checks + check instances
 
 	tec.Parent.Unlink(UnlinkRequest{

--- a/internal/tree/attacher_group.go
+++ b/internal/tree/attacher_group.go
@@ -38,7 +38,8 @@ func (teg *Group) ReAttach(a AttachRequest) {
 		panic(`Group.ReAttach: not attached`)
 	}
 	teg.deletePropertyAllInherited()
-	// TODO delete all inherited checks + check instances
+	teg.deleteCheckAllInherited()
+	teg.updateCheckInstances()
 
 	teg.Parent.Unlink(UnlinkRequest{
 		ParentType: teg.Parent.(Builder).GetType(),
@@ -77,6 +78,7 @@ func (teg *Group) Destroy() {
 	teg.deletePropertyAllLocal()
 	teg.deletePropertyAllInherited()
 	teg.deleteCheckLocalAll()
+	teg.deleteCheckAllInherited()
 	teg.updateCheckInstances()
 
 	wg := new(sync.WaitGroup)
@@ -110,6 +112,8 @@ func (teg *Group) Detach() {
 	bucket := teg.Parent.(Bucketeer).GetBucket()
 
 	teg.deletePropertyAllInherited()
+	teg.deleteCheckAllInherited()
+	teg.updateCheckInstances()
 	// TODO delete all inherited checks + check instances
 
 	teg.Parent.Unlink(UnlinkRequest{

--- a/internal/tree/attacher_node.go
+++ b/internal/tree/attacher_node.go
@@ -38,7 +38,8 @@ func (ten *Node) ReAttach(a AttachRequest) {
 		panic(`Node.ReAttach: not attached`)
 	}
 	ten.deletePropertyAllInherited()
-	// TODO delete all inherited checks + check instances
+	ten.deleteCheckAllInherited()
+	ten.updateCheckInstances()
 
 	ten.Parent.Unlink(UnlinkRequest{
 		ParentType: ten.Parent.(Builder).GetType(),
@@ -77,6 +78,7 @@ func (ten *Node) Destroy() {
 	ten.deletePropertyAllLocal()
 	ten.deletePropertyAllInherited()
 	ten.deleteCheckLocalAll()
+	ten.deleteCheckAllInherited()
 	ten.updateCheckInstances()
 
 	ten.Parent.Unlink(UnlinkRequest{
@@ -100,7 +102,8 @@ func (ten *Node) Detach() {
 	bucket := ten.Parent.(Bucketeer).GetBucket()
 
 	ten.deletePropertyAllInherited()
-	// TODO delete all inherited checks + check instances
+	ten.deleteCheckAllInherited()
+	ten.updateCheckInstances()
 
 	ten.Parent.Unlink(UnlinkRequest{
 		ParentType: ten.Parent.(Builder).GetType(),

--- a/internal/tree/checker_bucket.go
+++ b/internal/tree/checker_bucket.go
@@ -9,8 +9,9 @@
 package tree
 
 import (
-	"github.com/satori/go.uuid"
 	"sync"
+
+	"github.com/satori/go.uuid"
 )
 
 // Implementation of the `Checker` interface
@@ -97,6 +98,16 @@ func (teb *Bucket) addCheck(c Check) {
 func (teb *Bucket) DeleteCheck(c Check) {
 	teb.deleteCheckOnChildren(c)
 	teb.rmCheck(c)
+}
+
+func (teb *Bucket) deleteCheckAllInherited() {
+	for _, check := range teb.Checks {
+		if check.GetIsInherited() {
+			teb.deleteCheckInherited(check.Clone())
+		}
+
+	}
+
 }
 
 func (teb *Bucket) deleteCheckInherited(c Check) {

--- a/internal/tree/checker_cluster.go
+++ b/internal/tree/checker_cluster.go
@@ -94,6 +94,16 @@ func (tec *Cluster) deleteCheckInherited(c Check) {
 	tec.rmCheck(c)
 }
 
+func (tec *Cluster) deleteCheckAllInherited() {
+	for _, check := range tec.Checks {
+		if check.GetIsInherited() {
+			tec.deleteCheckInherited(check.Clone())
+		}
+
+	}
+
+}
+
 func (tec *Cluster) deleteCheckOnChildren(c Check) {
 	switch deterministicInheritanceOrder {
 	case true:

--- a/internal/tree/checker_group.go
+++ b/internal/tree/checker_group.go
@@ -101,6 +101,16 @@ func (teg *Group) DeleteCheck(c Check) {
 	teg.rmCheck(c)
 }
 
+func (teg *Group) deleteCheckAllInherited() {
+	for _, check := range teg.Checks {
+		if check.GetIsInherited() {
+			teg.deleteCheckInherited(check.Clone())
+		}
+
+	}
+
+}
+
 func (teg *Group) deleteCheckInherited(c Check) {
 	teg.deleteCheckOnChildren(c)
 	teg.rmCheck(c)

--- a/internal/tree/checker_node.go
+++ b/internal/tree/checker_node.go
@@ -57,6 +57,16 @@ func (ten *Node) DeleteCheck(c Check) {
 	ten.rmCheck(c)
 }
 
+func (ten *Node) deleteCheckAllInherited() {
+	for _, check := range ten.Checks {
+		if check.GetIsInherited() {
+			ten.deleteCheckInherited(check.Clone())
+		}
+
+	}
+
+}
+
 func (ten *Node) deleteCheckInherited(c Check) {
 	ten.rmCheck(c)
 }

--- a/internal/tree/validation.go
+++ b/internal/tree/validation.go
@@ -82,7 +82,7 @@ func specGroupCheck(spec GroupSpec) bool {
 	}
 	l := utf8.RuneCountInString(spec.Name)
 	switch {
-	case l < 4:
+	case l < 2:
 		return false
 	case l > 256:
 		return false
@@ -107,7 +107,7 @@ func specClusterCheck(spec ClusterSpec) bool {
 	}
 	l := utf8.RuneCountInString(spec.Name)
 	switch {
-	case l < 4:
+	case l < 2:
 		return false
 	case l > 256:
 		return false


### PR DESCRIPTION
This fixes the automatic deprovisioning / deletion / recreation of check instances if a node/group/cluster gets destroyed or moved within the tree.